### PR TITLE
Dnd5e biography support

### DIFF
--- a/src/apps/unkenny-sheet.hbs
+++ b/src/apps/unkenny-sheet.hbs
@@ -17,6 +17,11 @@
             <textarea name="preamble" rows="15">{{preamble}}</textarea>
         </div>
 
+        <div class='form-field'>
+            <label>{{localize "unkenny.sheet.includeBiography"}}</label>
+            <input name="includeBiography" type="checkbox" {{#if includeBiography}}checked{{/if}}>
+        </div>
+
         <header class="flex-header">
             <h3>
                 {{localize "unkenny.sheet.overwrite"}}

--- a/src/apps/unkenny-sheet.js
+++ b/src/apps/unkenny-sheet.js
@@ -1,4 +1,3 @@
-
 import { findActorWithAlias } from "../scripts/chat-message-request.js";
 import { getModelToTextMap } from "../scripts/models.js";
 import { PREFIX_OPTIONS } from "../scripts/prefix.js";
@@ -22,6 +21,8 @@ class UnKennySheet extends DocumentSheet {
             this.initPrefixes();
             await this.initContextWithActorData();
         }
+
+        this.context.includeBiography = await this.object.getFlag("unkenny", "includeBiography") || false;
 
         return this.context;
     }
@@ -98,6 +99,8 @@ class UnKennySheet extends DocumentSheet {
         } else {
             await this.updateFlag(formData, "prefix");
         }
+
+        await this.object.setFlag("unkenny", "includeBiography", formData.includeBiography);
 
         const actor = await findActorWithAlias(formData.alias);
         if (!actor) {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -48,5 +48,6 @@
     "unkenny.sheet.preamble": "Preamble",
     "unkenny.sheet.overwrite": "Overwrite Global Parameters",
     "unkenny.sheet.save": "Save",
-    "unkenny.sheet.settingAliasFailed": "Actor not found, setting alias failed."
+    "unkenny.sheet.settingAliasFailed": "Actor not found, setting alias failed.",
+    "unkenny.sheet.includeBiography": "Include Biography Details"
 }

--- a/src/scripts/chat-message-response.js
+++ b/src/scripts/chat-message-response.js
@@ -22,10 +22,19 @@ async function triggerResponse(actor, request) {
     let alias = await actor.getFlag("unkenny", "alias");
     request = replaceAlias(request, alias, name);
 
+    let preamble = await actor.getFlag("unkenny", "preamble") || "";
     let parameters = await getGenerationParameters(actor);
     if (!parameters) {
         return;
     }
+
+    if (await actor.getFlag("unkenny", "includeBiography") && parameters.biography.trim()) {
+        preamble += `\n\n${parameters.biography}`;
+    }
+
+    console.log("Constructed Preamble:", preamble);
+
+    request = `${preamble}\n\n${request}`;
 
     let response = await generateResponse(actor, request, parameters);
 

--- a/src/scripts/llm.js
+++ b/src/scripts/llm.js
@@ -31,6 +31,11 @@ async function getGenerationParameters(actor) {
     }
     let params = {};
     params.actorName = actor.name;
+
+    // Fetch biography from the actor's character sheet
+    const biography = actor.system.details.biography?.value || ""; // Adjusted to access the correct property
+    params.biography = biography.slice(0, 1000); // Limit to 1000 characters
+
     for (let key in llmParametersAndDefaults()) {
         const param = await getGenerationParameter(actor, key);
         if (param == null) {


### PR DESCRIPTION
![ezgif-1-f6e577b661](https://github.com/user-attachments/assets/85b0ec9c-c35a-4bb0-b323-b023e51ab334)

Added a checkbox to the Unkenniness Parameters so that DM can choose to include the biography section of the actors sheet in the preamble being sent to the LLM. This makes it where if the actor already has a Biography you can just add some additional instructions in the preamble to explain how the NPC should talk or behave while handling their backstory from their Bio.